### PR TITLE
Support /api/getIdols and /api/getTribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ You can use this proxy to make cross-origin requests. You do not need to request
 
 Replace `www.blaseball.com` in your endpoint URL with `cors-proxy.blaseball-reference.com`, and it should just work.
 
-Endpoints under `/database` and `/events` are supported. Directly accessing the proxy is not supported (requests must have an `Origin` or `X-Requested-With` header).
+Endpoints under `/database` and `/events` are supported, as are `/api/getIdols` and `/api/getTribute`. Directly accessing the proxy is not supported (requests must have an `Origin` or `X-Requested-With` header).
 
 If you are accessing an event source under `/events`, plan to add code to re-open the socket after the connection is closed.
 

--- a/lib/handler.ts
+++ b/lib/handler.ts
@@ -42,7 +42,7 @@ export const onRequest: CloudFrontRequestHandler = async (event) => {
   const { request } = event.Records[0].cf;
 
   if (request.uri === '/') {
-    const body = 'This API enables cross-origin requests to read-only Blaseball endpoints (/database and /events).\n\n'
+    const body = 'This API enables cross-origin requests to read-only Blaseball endpoints (/database, /events, /api/getTribute, and /api/getIdols).\n\n'
           + 'Cookies are disabled and stripped from requests. Redirects are not followed, as they should be\n'
           + 'handled by the browser.\n\n'
           + 'To prevent the use of the proxy for casual browsing, the API requires either the Origin or the\n'
@@ -51,7 +51,7 @@ export const onRequest: CloudFrontRequestHandler = async (event) => {
     return textResponse('200', body);
   }
 
-  if (!['/events', '/database'].some((s) => request.uri.startsWith(s))) {
+  if (!['/events', '/database', '/api/getTribute', '/api/getIdols'].some((s) => request.uri.startsWith(s))) {
     return textResponse('404', '404 Not Found');
   }
 


### PR DESCRIPTION
Adds support for `/api/getTribute` (which [abslve](https://slavfox.space/abslve/) is using to show HoF stars) and `/api/getIdols` (which was also suggested in the SIBRcord).